### PR TITLE
upgrade enkan-version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <enkan.version>0.1.2-SNAPSHOT</enkan.version>
-        <enkan.undertow.version>0.1.2-SNAPSHOT</enkan.undertow.version>
-        <enkan.thymeleaf.version>0.1.2-SNAPSHOT</enkan.thymeleaf.version>
-        <enkan.flyway.version>0.1.2-SNAPSHOT</enkan.flyway.version>
-        <enkan.doma2.version>0.1.2-SNAPSHOT</enkan.doma2.version>
-        <enkan.HikariCP.version>0.1.2-SNAPSHOT</enkan.HikariCP.version>
-        <enkan.jackson.version>0.1.2-SNAPSHOT</enkan.jackson.version>
-        <kotowari.version>0.1.2-SNAPSHOT</kotowari.version>
+        <enkan.version>0.1.2</enkan.version>
+        <enkan.undertow.version>0.1.2</enkan.undertow.version>
+        <enkan.thymeleaf.version>0.1.2</enkan.thymeleaf.version>
+        <enkan.flyway.version>0.1.2</enkan.flyway.version>
+        <enkan.doma2.version>0.1.2</enkan.doma2.version>
+        <enkan.HikariCP.version>0.1.2</enkan.HikariCP.version>
+        <enkan.jackson.version>0.1.2</enkan.jackson.version>
+        <kotowari.version>0.1.2</kotowari.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <enkan.version>0.1.1</enkan.version>
-        <enkan.undertow.version>0.1.1</enkan.undertow.version>
-        <enkan.thymeleaf.version>0.1.1</enkan.thymeleaf.version>
-        <enkan.flyway.version>0.1.1</enkan.flyway.version>
-        <enkan.doma2.version>0.1.1</enkan.doma2.version>
-        <enkan.HikariCP.version>0.1.1</enkan.HikariCP.version>
-        <enkan.jackson.version>0.1.1</enkan.jackson.version>
-        <kotowari.version>0.1.1</kotowari.version>
+        <enkan.version>0.1.2-SNAPSHOT</enkan.version>
+        <enkan.undertow.version>0.1.2-SNAPSHOT</enkan.undertow.version>
+        <enkan.thymeleaf.version>0.1.2-SNAPSHOT</enkan.thymeleaf.version>
+        <enkan.flyway.version>0.1.2-SNAPSHOT</enkan.flyway.version>
+        <enkan.doma2.version>0.1.2-SNAPSHOT</enkan.doma2.version>
+        <enkan.HikariCP.version>0.1.2-SNAPSHOT</enkan.HikariCP.version>
+        <enkan.jackson.version>0.1.2-SNAPSHOT</enkan.jackson.version>
+        <kotowari.version>0.1.2-SNAPSHOT</kotowari.version>
     </properties>
 
     <build>


### PR DESCRIPTION
### 概要
enkanバージョンを0.1.2にしました。

### 背景
Sessionから プロジェクトpackageのシリアライズオブジェクトを取得できるようにするため

### TODO
- [x] sessionからオブジェクトを取得できる
- [x] `/x-enkan/requests` でリクエスト履歴を閲覧できる